### PR TITLE
Update build.properties

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.2
+sbt.version=1.7.1


### PR DESCRIPTION
SecurityManager has been removed in Java 18, using old version of sbt leads to this exception:
java.lang.UnsupportedOperationException: The Security Manager is deprecated and will be removed in a future release